### PR TITLE
Add Env Var to skip branch validation

### DIFF
--- a/source/src/scanner.ts
+++ b/source/src/scanner.ts
@@ -26,6 +26,10 @@ export function validateEnv(env: any, params: BoostParams) {
     throw Error("this extension only supports Github and TfsGit repositories")
   }
 
+  if (execEnv.SKIP_BRANCH_VALIDATION !== undefined) {
+    return;
+  }
+
   if (execEnv.BUILD_REASON == "Manual") {
     const sourceBranch =
       execEnv.SYSTEM_PULLREQUEST_SOURCEBRANCH ?? execEnv.BUILD_SOURCEBRANCHNAME

--- a/source/tests/scanner.ts
+++ b/source/tests/scanner.ts
@@ -177,6 +177,21 @@ describe("validateEnv", () => {
     )
   })
 
+  test("skips branch validation when SKIP_BRANCH_VALIDATION is defined", async () => {
+    const params = new BoostParams(process.env, task)
+    process.env.BUILD_REPOSITORY_PROVIDER = "GitHub"
+    process.env.BUILD_REASON = "Manual"
+    process.env.SYSTEM_PULLREQUEST_SOURCEBRANCH = "invalid"
+
+    expect(() => {
+      scanner.validateEnv(process.env, params)
+    }).toThrow(scanner.ExecutionError)
+
+    // Value is irrelevant, just needs to be defined
+    process.env.SKIP_BRANCH_VALIDATION = ""
+    scanner.validateEnv(process.env, params)
+  })
+
   describe("when BUILD_REASON is Manual", () => {
     test("passes when BUILD_SOURCEBRANCHNAME is main branch", async () => {
       const params = new BoostParams(process.env, task)


### PR DESCRIPTION
When running the scanner with ZTP, we manually set all relevant branch / sha values, so we can skip the checks for a sane ADO environment.