### PR TITLE
Ignore apiEndpoint if value is an empty string

### DIFF
--- a/source/src/params.ts
+++ b/source/src/params.ts
@@ -90,28 +90,29 @@ export class BoostParams extends BoostParamsVars {
   }
 
   public loadInputs(tl: TaskLib) {
-    this.additionalArgs = tl.getInput("additionalArgs")
-    this.apiEnabled = tl.getInput("apiEnabled")
-    this.apiEndpoint = tl.getInput("apiEndpoint")
-    this.apiToken = tl.getInput("apiToken")
-    this.cliUrl = tl.getInput("cliUrl") ?? this.cliUrl
-    this.cliVersion = tl.getInput("cliVersion") ?? this.cliVersion
-    this.ignoreFailure = tl.getInput("ignoreFailure")
-    this.logColors = tl.getInput("logColors") ?? this.logColors
-    this.logLevel = tl.getInput("logLevel")
-    this.mainBranch = tl.getInput("mainBranch")
-    this.preScanCmd = tl.getInput("preScanCmd")
-    this.registryModule = tl.getInput("registryModule")
-    this.registryPath = tl.getInput("registryPath")
-    this.scanLabel = tl.getInput("scanLabel")
-    this.scannerId = tl.getInput("scannerId")
-    this.scanPath = tl.getInput("scanPath")
-    this.scanTimeout = tl.getInput("scanTimeout")
-    this.workingDirectory = tl.getInput("workingDirectory")
+    this.additionalArgs = this.loadInput(tl, "additionalArgs")
+    this.apiEnabled = this.loadInput(tl, "apiEnabled")
+    this.apiEndpoint = this.loadInput(tl, "apiEndpoint")
+    this.apiToken = this.loadInput(tl, "apiToken")
+    this.cliUrl = this.loadInput(tl, "cliUrl") ?? this.cliUrl
+    this.cliVersion = this.loadInput(tl, "cliVersion") ?? this.cliVersion
+    this.ignoreFailure = this.loadInput(tl, "ignoreFailure")
+    this.logColors = this.loadInput(tl, "logColors") ?? this.logColors
+    this.logLevel = this.loadInput(tl, "logLevel")
+    this.mainBranch = this.loadInput(tl, "mainBranch")
+    this.preScanCmd = this.loadInput(tl, "preScanCmd")
+    this.registryModule = this.loadInput(tl, "registryModule")
+    this.registryPath = this.loadInput(tl, "registryPath")
+    this.scanLabel = this.loadInput(tl, "scanLabel")
+    this.scannerId = this.loadInput(tl, "scannerId")
+    this.scanPath = this.loadInput(tl, "scanPath")
+    this.scanTimeout = this.loadInput(tl, "scanTimeout")
+    this.workingDirectory = this.loadInput(tl, "workingDirectory")
+  }
 
-    if (this.apiEndpoint === "") {
-        this.apiEndpoint = undefined;
-    }
+  public loadInput(tl: TaskLib, name: string): string | undefined {
+    let value = tl.getInput(name);
+    return value !== "" ? value : undefined;
   }
 
   public loadEnv(env: any) {

--- a/source/src/params.ts
+++ b/source/src/params.ts
@@ -108,6 +108,10 @@ export class BoostParams extends BoostParamsVars {
     this.scanPath = tl.getInput("scanPath")
     this.scanTimeout = tl.getInput("scanTimeout")
     this.workingDirectory = tl.getInput("workingDirectory")
+
+    if (this.apiEndpoint === "") {
+        this.apiEndpoint = undefined;
+    }
   }
 
   public loadEnv(env: any) {

--- a/source/tests/params.ts
+++ b/source/tests/params.ts
@@ -103,13 +103,47 @@ describe("BoostParams", () => {
     expect(params.asBoostEnv().BOOST_API_TOKEN).toStrictEqual("input value")
   })
 
-  test("ensures apiEndpoint is set to undefined if empty", async () => {
-    const mockGetInput = () => ""
+  test("ensures values are treated as undefined if they're present as empty strings", async () => {
+    const mockGetInput = () => "";
     const mockTl = {
       getInput: mockGetInput,
     }
 
     const params = new BoostParams({}, mockTl)
-    expect(params.asBoostEnv().BOOST_API_ENDPOINT).toStrictEqual(undefined)
+    expect(params.additionalArgs).toStrictEqual(undefined);
+    expect(params.apiEnabled).toStrictEqual(undefined);
+    expect(params.apiEndpoint).toStrictEqual(undefined);
+    expect(params.apiToken).toStrictEqual(undefined);
+    expect(params.ignoreFailure).toStrictEqual(undefined);
+    expect(params.logLevel).toStrictEqual(undefined);
+    expect(params.mainBranch).toStrictEqual(undefined);
+    expect(params.preScanCmd).toStrictEqual(undefined);
+    expect(params.registryModule).toStrictEqual(undefined);
+    expect(params.registryPath).toStrictEqual(undefined);
+    expect(params.scanLabel).toStrictEqual(undefined);
+    expect(params.scannerId).toStrictEqual(undefined);
+    expect(params.scanPath).toStrictEqual(undefined);
+    expect(params.scanTimeout).toStrictEqual(undefined);
+    expect(params.workingDirectory).toStrictEqual(undefined);
+    expect(params.cliUrl).toStrictEqual("https://assets.build.boostsecurity.io");
+    expect(params.cliVersion).toStrictEqual("1");
+    expect(params.logColors).toStrictEqual("true");
+  })
+
+  const LoadInputTestCases = [
+    [undefined, undefined],
+    ["", undefined],
+    ["some-value", "some-value"],
+  ]
+  test.each(LoadInputTestCases)(
+    "loadInput loads %s as %s ",
+    async (value: string | undefined, expected: string | undefined) => {
+      const mockGetInput = () => value;
+      const mockTl = {
+        getInput: mockGetInput,
+      }
+
+      const params = new BoostParams({}, mockTl)
+      expect(params.loadInput(mockTl, "some-value")).toStrictEqual(expected);
   })
 })

--- a/source/tests/params.ts
+++ b/source/tests/params.ts
@@ -102,4 +102,14 @@ describe("BoostParams", () => {
     const params = new BoostParams({ BOOST_API_TOKEN: "env value" }, mockTl)
     expect(params.asBoostEnv().BOOST_API_TOKEN).toStrictEqual("input value")
   })
+
+  test("ensures apiEndpoint is set to undefined if empty", async () => {
+    const mockGetInput = () => ""
+    const mockTl = {
+      getInput: mockGetInput,
+    }
+
+    const params = new BoostParams({}, mockTl)
+    expect(params.asBoostEnv().BOOST_API_ENDPOINT).toStrictEqual(undefined)
+  })
 })


### PR DESCRIPTION
In the azure-pipelines.yml file generated by ZTP, we offer the option to 
override the api endpoint with the BOOST_API_ENDPOINT environment variable. 
However, if that variable is not set, the scanner will still see it defined in 
the env and will read it as an empty string, and will propagate that empty 
string to the scanner.

If the value is present but empty, it should be treated as absent.

For reference, this is the relevant part from azure-pipelines.yml:
```yaml
    inputs:
      apiToken: $(BOOST_API_TOKEN)
      apiEndpoint: $(BOOST_API_ENDPOINT)
      registryModule: ${{ parameters.registry_module }}
      workingDirectory: target
```
