### PR TITLE
BST-13206: add support for triggerId

### DIFF
--- a/source/src/params.ts
+++ b/source/src/params.ts
@@ -34,6 +34,7 @@ const BoostParamEnvMap: BoostParamEnvMap = {
   scanDiffTimeout: "BOOST_DIFF_SCAN_TIMEOUT",
   scanMainTimeout: "BOOST_MAIN_SCAN_TIMEOUT",
   tmpDir: "BOOST_TMP_DIR",
+  triggerId: "BOOST_TRIGGER_ID",
   workingDirectory: "BOOST_WORKING_DIRECTORY",
 }
 
@@ -60,6 +61,7 @@ class BoostParamsVars {
   scanDiffTimeout: string | undefined = ""
   scanMainTimeout: string | undefined = ""
   tmpDir: string = ""
+  triggerId: string | undefined = ""
   workingDirectory: string | undefined = ""
 }
 
@@ -120,6 +122,7 @@ export class BoostParams extends BoostParamsVars {
     this.scanTimeout = tl.getInput("scanTimeout")
     this.scanDiffTimeout = tl.getInput("scanDiffTimeout")
     this.scanMainTimeout = tl.getInput("scanMainTimeout")
+    this.triggerId = tl.getInput("triggerId")
     this.workingDirectory = tl.getInput("workingDirectory")
   }
 

--- a/source/src/scanner.ts
+++ b/source/src/scanner.ts
@@ -77,7 +77,12 @@ export async function executeCLI(params: BoostParams) {
   }
 
   const cliRunner = task.tool(params.exePath)
-  cliRunner.arg(["scan", "repo"])
+  if (params.triggerId != undefined) {
+    cliRunner.arg(["scan", "trigger"])
+  } else {
+    cliRunner.arg(["scan", "repo"])
+  }
+  
   if (params.additionalArgs) {
     cliRunner.arg(params.additionalArgs.split(" "))
   }

--- a/source/tests/params.ts
+++ b/source/tests/params.ts
@@ -64,6 +64,7 @@ describe("BoostParams", () => {
     ["BOOST_DIFF_SCAN_TIMEOUT", "scanTimeout"],
     ["BOOST_DIFF_SCAN_TIMEOUT", "scanDiffTimeout"],
     ["BOOST_MAIN_SCAN_TIMEOUT", "scanMainTimeout"],
+    ["BOOST_TRIGGER_ID", "triggerId"],
     ["BOOST_WORKING_DIRECTORY", "workingDirectory"],
   ]
 

--- a/source/tests/scanner.ts
+++ b/source/tests/scanner.ts
@@ -4,8 +4,8 @@ import * as fs from "fs"
 import * as os from "os"
 import * as path from "path"
 
-import * as scanner from "../src/scanner"
 import { BoostParams } from "../src/params"
+import * as scanner from "../src/scanner"
 
 const INITIAL_ENV = process.env
 
@@ -101,6 +101,28 @@ describe("executeCLI", () => {
 
     await scanner.executeCLI(params)
     expect(mockArg).toHaveBeenCalledWith(["scan", "repo"])
+    expect(mockExec).toHaveBeenCalledWith({
+      env: params.asExecEnv(process.env),
+    })
+  })
+
+  test("executes with trigger command", async () => {
+    const params = new BoostParams(process.env, task)
+    params.exePath = path.join(params.tmpDir, "script")
+    params.triggerId = "trigger"
+
+    fs.closeSync(fs.openSync(params.exePath, "w"))
+
+    const mockTool = task.tool as jest.Mock
+    const mockArg = jest.fn()
+    const mockExec = jest.fn(async () => 0)
+    mockTool.mockReturnValue({
+      arg: mockArg,
+      exec: mockExec,
+    })
+
+    await scanner.executeCLI(params)
+    expect(mockArg).toHaveBeenCalledWith(["scan", "trigger"])
     expect(mockExec).toHaveBeenCalledWith({
       env: params.asExecEnv(process.env),
     })


### PR DESCRIPTION
add support to parse the new triggerId parameter
and execute the `scan trigger` subcommand when needed